### PR TITLE
add support for UNI-T UT61E with serial cable

### DIFF
--- a/src/forms/uidmmprefs.ui
+++ b/src/forms/uidmmprefs.ui
@@ -575,6 +575,11 @@
           <string>22 bytes binary, continuous (DO3122)</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>14 bytes half-ASCII, UNI-T UT61E</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item>

--- a/src/sources/dmm.h
+++ b/src/sources/dmm.h
@@ -87,6 +87,7 @@ class DMM : public QObject
 	  void						readQM1537Continuous( const QByteArray & data, int id, ReadEvent::DataFormat df );
 	  void						readRS22812Continuous( const QByteArray & data, int id, ReadEvent::DataFormat df );
       void						readDO3122Continuous( const QByteArray & data, int id, ReadEvent::DataFormat df );
+	  void						readCyrustekES51922(const QByteArray & data, int id, ReadEvent::DataFormat df);
 	  const char				*vc820Digit( int );
 	  const char				*RS22812Digit( int );
       const char                *DO3122Digit( int byte, bool *convOk );

--- a/src/sources/dmmprefs.cpp
+++ b/src/sources/dmmprefs.cpp
@@ -118,6 +118,7 @@ struct DMMInfo dmm_info[] = {
 							  {"Uni-Trend UT30E", 3, 5, 8, 1, 1, 0, 1, 0, 0,1,1,1},   // no image
 							  {"Uni-Trend UT61B", 3, 8, 8, 1, 1, 0, 1, 0, 0,1,1,1},   // no image
 							  {"Uni-Trend UT61D", 3, 8, 8, 1, 1, 0, 8, 0, 0,0,0,1},   // no image
+							  {"Uni-Trend UT61E", 6, 12, 7, 1, 1, 2, 2, 0, 0,0,0,1},   // no image
 
 							  {"Voltcraft M-3610D", 1, 0, 7, 2, 1, 0, 1, 0, 0,1,1,1},  // no image
 							  {"Voltcraft M-3650D", 1, 0, 7, 2, 1, 0, 1, 0, 0,1,1,1},

--- a/src/sources/readerthread.cpp
+++ b/src/sources/readerthread.cpp
@@ -170,6 +170,8 @@ int  ReaderThread::formatLength() const
 		return 9;
       case ReadEvent::DO3122Continuous:
         return 22;
+      case ReadEvent::CyrustekES51922:
+        return 14;
   }
   return 0;
 }
@@ -213,6 +215,9 @@ void ReaderThread::readDMM()
 		  break;
       case ReadEvent::DO3122Continuous:
           readDO3122Continuous();
+          break;
+      case ReadEvent::CyrustekES51922:
+          readCyrustekES51922();
           break;
   }
 }
@@ -277,6 +282,11 @@ bool ReaderThread::checkFormat()
   {
 	if (m_fifo[m_length] == 0x0d)
 		return true;
+  }
+  else if (m_format == ReadEvent::CyrustekES51922)
+  {
+    if ((m_length) && (m_fifo[m_length - 1] == 0x0d) && (m_fifo[m_length] == 0x0a))
+      return true;
   }
   else if (m_format == ReadEvent::RS22812Continuous)
   {
@@ -593,5 +603,9 @@ void ReaderThread::readRS22812Continuous()
 }
 
 void ReaderThread::readDO3122Continuous()
+{
+}
+
+void ReaderThread::readCyrustekES51922()
 {
 }

--- a/src/sources/readerthread.h
+++ b/src/sources/readerthread.h
@@ -77,6 +77,7 @@ class ReaderThread : public QObject
 	  void					readVC940();
 	  void					readRS22812Continuous();
       void                  readDO3122Continuous();
+      void                  readCyrustekES51922();
 
 	  int					formatLength() const;
 	  bool					checkFormat();

--- a/src/sources/readevent.h
+++ b/src/sources/readevent.h
@@ -41,7 +41,8 @@ class ReadEvent
 		QM1537Continuous,
 		RS22812Continuous,
 		VC870Continuous,
-        DO3122Continuous
+        DO3122Continuous,
+		CyrustekES51922
 	  };
 };
 #endif // READEVENT_HH


### PR DESCRIPTION
I used the original serial cable + usb-serial adapter.

The adapter must support RTS and DTR.
code is taken from https://github.com/mw46d/QtDMM but without lots of additional changes.